### PR TITLE
EditableLabel: extended and added new features, cleaned up props naming

### DIFF
--- a/src/components/elements/EditableLabel/EditableLabel.stories.jsx
+++ b/src/components/elements/EditableLabel/EditableLabel.stories.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import LiveEditDecorator from 'decorators/LiveEditDecorator';
-import StoryWithHooks from 'decorators/StoryWithHooks';
 import EditableLabel from './EditableLabel';
 
 export default {
@@ -10,15 +9,9 @@ export default {
     decorators: [LiveEditDecorator({ EditableLabel })]
 };
 
-export const basic = () => <EditableLabel />;
+export const basic = () => <EditableLabel placeholder="Enter your text here..." />;
 basic.story = {
     name: 'Default'
 };
 
-export const readOnly = () => <EditableLabel isEditEnable={false} text="Sample Text" />;
-
-export const editable = StoryWithHooks(() => {
-    const [text, setText] = React.useState('');
-
-    return <EditableLabel placeholder="Enter your text here..." onEditDone={setText} text={text} />;
-});
+export const readOnly = () => <EditableLabel enabled={false} value="Sample Text" />;

--- a/test/EditableLabel.test.jsx
+++ b/test/EditableLabel.test.jsx
@@ -1,101 +1,104 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import EditableLabel from '../src/components/elements/EditableLabel';
 
 describe('<EditableLabel />', () => {
+    function expectEditMode(wrapper, editMode = true) {
+        expect(wrapper.exists('Label')).toEqual(!editMode);
+        expect(wrapper.exists('Input')).toEqual(editMode);
+    }
+
     describe('in edit mode', () => {
         it('renders', () => {
-            const wrapper = shallow(<EditableLabel text="Text" isEditEnable placeholder="Enter something" />);
+            const wrapper = shallow(<EditableLabel value="Text" enabled placeholder="Enter something" />);
             expect(wrapper.exists()).toEqual(true);
         });
 
-        it('renders label when in edit mode', () => {
-            const wrapper = shallow(<EditableLabel text="Text" isEditEnable placeholder="Enter something" />);
-            expect(wrapper.exists('label')).toEqual(true);
+        it('renders Label when in edit mode', () => {
+            const wrapper = shallow(<EditableLabel value="Text" enabled placeholder="Enter something" />);
+            expectEditMode(wrapper, false);
         });
 
         it('shows text properly', () => {
-            const wrapper = shallow(<EditableLabel text="Text" isEditEnable placeholder="Enter something" />);
-            expect(wrapper.find('label').text()).toEqual('Text');
-            expect(wrapper.find('label').hasClass('editPlaceholder')).toEqual(false);
+            const wrapper = mount(<EditableLabel value="Text" enabled placeholder="Enter something" />);
+            expect(wrapper.find('Label').text()).toEqual('Text');
+            expect(wrapper.find('Label').hasClass('editPlaceholder')).toEqual(false);
         });
 
         it('shows placeholder if text is empty (in edit mode)', () => {
-            const emptyWrapper = shallow(<EditableLabel isEditEnable placeholder="Enter something" />);
-            expect(emptyWrapper.find('label').text()).toEqual('Enter something');
-            expect(emptyWrapper.find('label').hasClass('editPlaceholder')).toEqual(true);
+            const emptyWrapper = mount(<EditableLabel enabled placeholder="Enter something" />);
+            expect(emptyWrapper.find('Label').text()).toEqual('Enter something');
+            expect(emptyWrapper.find('Label').hasClass('editPlaceholder')).toEqual(true);
         });
 
         it('allows to edit text', () => {
-            const editDoneCallback = jest.fn();
-            const wrapper = shallow(
-                <EditableLabel isEditEnable placeholder="Enter something" onEditDone={editDoneCallback} />
-            );
+            const onChange = jest.fn();
+            const wrapper = mount(<EditableLabel enabled placeholder="Enter something" onChange={onChange} />);
 
-            // Click on label
+            // Click on Label
             wrapper
-                .find('label')
+                .find('Label')
                 .first()
                 .simulate('click', { stopPropagation: () => {} });
-            expect(wrapper.exists('label')).toEqual(false);
-            expect(wrapper.exists('input')).toEqual(true);
-
-            // Click on input
-            wrapper
-                .find('input')
-                .first()
-                .simulate('click', { stopPropagation: () => {} });
-            expect(wrapper.exists('label')).toEqual(false);
-            expect(wrapper.exists('input')).toEqual(true);
+            expectEditMode(wrapper);
 
             // Write something
-            wrapper
-                .find('input')
-                .first()
-                .simulate('keydown', { key: 'X' });
-            expect(editDoneCallback).not.toHaveBeenCalled();
-            wrapper
-                .find('input')
-                .first()
-                .simulate('keydown', { key: 'Y' });
-            expect(editDoneCallback).not.toHaveBeenCalled();
+            wrapper.find('input').simulate('change', { target: { value: 'XY' } });
+            expect(onChange).not.toHaveBeenCalled();
 
             // Enter key press
+            wrapper.find('input').simulate('keydown', { key: 'Enter' });
+            expect(onChange).toHaveBeenCalled();
+            expectEditMode(wrapper, false);
+        });
+
+        it('allows to cancel edit on Esc press', () => {
+            const onChange = jest.fn();
+            const initialValue = 'initial';
+            const wrapper = mount(<EditableLabel enabled value={initialValue} onChange={onChange} />);
+
+            // Click on Label
             wrapper
-                .find('input')
+                .find('Label')
                 .first()
-                .simulate('keypress', { key: 'Enter' });
-            expect(editDoneCallback).toHaveBeenCalled();
-            expect(wrapper.exists('label')).toEqual(true);
-            expect(wrapper.exists('input')).toEqual(false);
+                .simulate('click', { stopPropagation: () => {} });
+            expectEditMode(wrapper);
+
+            // Write something
+            wrapper.find('input').simulate('change', { target: { value: 'XY' } });
+
+            // Enter key press
+            wrapper.find('input').simulate('keydown', { key: 'Escape' });
+            expect(onChange).not.toHaveBeenCalled();
+            expectEditMode(wrapper, false);
+            expect(wrapper.find('Label').text()).toEqual(initialValue);
         });
     });
 
     describe('in non edit mode', () => {
         it('renders', () => {
-            const wrapper = shallow(<EditableLabel text="Text" isEditEnable={false} placeholder="Enter something" />);
+            const wrapper = shallow(<EditableLabel value="Text" enabled={false} placeholder="Enter something" />);
             expect(wrapper.exists()).toEqual(true);
         });
 
         it('shows text properly', () => {
-            const wrapper = shallow(<EditableLabel text="Text" isEditEnable={false} placeholder="Enter something" />);
-            expect(wrapper.find('label').text()).toEqual('Text');
+            const wrapper = mount(<EditableLabel value="Text" enabled={false} placeholder="Enter something" />);
+            expect(wrapper.find('Label').text()).toEqual('Text');
         });
 
         it('shows empty string text is empty', () => {
-            const emptyWrapper = shallow(<EditableLabel isEditEnable={false} placeholder="Enter something" />);
-            expect(emptyWrapper.find('label').text()).toEqual('');
+            const emptyWrapper = mount(<EditableLabel enabled={false} placeholder="Enter something" />);
+            expect(emptyWrapper.find('Label').text()).toEqual('');
         });
 
         it('does not allow to edit text', () => {
-            const wrapper = shallow(<EditableLabel isEditEnable={false} placeholder="Enter something" />);
+            const wrapper = shallow(<EditableLabel enabled={false} placeholder="Enter something" />);
             wrapper
-                .find('label')
+                .find('Label')
                 .first()
                 .simulate('click', { stopPropagation: () => {} });
 
-            expect(wrapper.exists('label')).toEqual(true);
-            expect(wrapper.exists('input')).toEqual(false);
+            expectEditMode(wrapper, false);
         });
     });
 });

--- a/test/__snapshots__/HtmlSnapshots.test.js.snap
+++ b/test/__snapshots__/HtmlSnapshots.test.js.snap
@@ -4784,30 +4784,31 @@ exports[`Storyshots Elements/Dropdown With Empty Option 1`] = `
 `;
 
 exports[`Storyshots Elements/EditableLabel Basic 1`] = `
-<label
-  className=" editPlaceholder"
+<div
+  className="ui label null editPlaceholder"
   onClick={[Function]}
->
-  Click to edit
-</label>
-`;
-
-exports[`Storyshots Elements/EditableLabel Editable 1`] = `
-<label
-  className=" editPlaceholder"
-  onClick={[Function]}
+  style={
+    Object {
+      "background": "none",
+      "cursor": "pointer",
+    }
+  }
 >
   Enter your text here...
-</label>
+</div>
 `;
 
 exports[`Storyshots Elements/EditableLabel Read Only 1`] = `
-<label
-  className=" "
+<div
+  className="ui label null "
   onClick={[Function]}
->
-  Sample Text
-</label>
+  style={
+    Object {
+      "background": "none",
+      "cursor": "inherit",
+    }
+  }
+/>
 `;
 
 exports[`Storyshots Elements/ErrorMessage Auto Hide 1`] = `


### PR DESCRIPTION
- used `Input` instead of `input` and `Label` instead of `label` for style consistency
- added ability co cancel edit on Esc key press
- added props to set label and input sizes
- added `invalidValues` prop that prevents entering invalid/reserved values
- added `onError` prop that can be used to provide a callback that is called when invalid/reserved value is entered (as specified by `invalidValues` prop)
- added pointer cursor when label is editable
- updated existing prop names to adhere to standard conventions