### PR TITLE
RD-1249 Fix cursor for non-selectable rows and segment items

### DIFF
--- a/src/components/data/DataSegment/SegmentItem.jsx
+++ b/src/components/data/DataSegment/SegmentItem.jsx
@@ -44,6 +44,6 @@ SegmentItem.propTypes = {
 
 SegmentItem.defaultProps = {
     selected: false,
-    onClick: () => {},
+    onClick: undefined,
     className: ''
 };

--- a/src/components/data/DataTable/DataTable.stories.jsx
+++ b/src/components/data/DataTable/DataTable.stories.jsx
@@ -62,7 +62,7 @@ export const pagination = () => {
             <DataTable.Column label="Blueprint" name="blueprint_id" />
             <DataTable.Column label="Deployment" name="deployment_id" />
             {logs.items.map(item => (
-                <DataTable.Row key={item.id} onClick={() => {}}>
+                <DataTable.Row key={item.id}>
                     <DataTable.Data>{item.id}</DataTable.Data>
                     <DataTable.Data>{item.blueprint_id}</DataTable.Data>
                     <DataTable.Data>{item.deployment_id}</DataTable.Data>
@@ -157,7 +157,7 @@ export const rowSpanAndStyle = () => {
             <DataTable.Column label="Deployment" name="deployment_id" />
             {_.map(grouped, ({ items, blueprintId }) =>
                 _.map(items, ({ id, deployment_id: deploymentId }, index) => (
-                    <DataTable.Row key={id} onClick={() => {}}>
+                    <DataTable.Row key={id}>
                         <DataTable.Data style={{ fontWeight: 'bold' }}>{id}</DataTable.Data>
                         {index === 0 && <DataTable.Data rowSpan={items.length}>{blueprintId}</DataTable.Data>}
                         <DataTable.Data>{deploymentId}</DataTable.Data>

--- a/src/components/data/DataTable/TableRow.jsx
+++ b/src/components/data/DataTable/TableRow.jsx
@@ -88,9 +88,9 @@ TableRow.propTypes = {
 TableRow.defaultProps = {
     id: undefined,
     selected: false,
-    onClick: () => {},
-    onMouseOver: () => {},
-    onMouseOut: () => {},
+    onClick: undefined,
+    onMouseOver: undefined,
+    onMouseOut: undefined,
     showCols: [],
     className: ''
 };

--- a/test/__snapshots__/HtmlSnapshots.test.js.snap
+++ b/test/__snapshots__/HtmlSnapshots.test.js.snap
@@ -258,12 +258,7 @@ exports[`Storyshots Data/DataSegment Action Buttons 1`] = `
   <div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -272,12 +267,7 @@ exports[`Storyshots Data/DataSegment Action Buttons 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -286,12 +276,7 @@ exports[`Storyshots Data/DataSegment Action Buttons 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -300,12 +285,7 @@ exports[`Storyshots Data/DataSegment Action Buttons 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -344,12 +324,7 @@ exports[`Storyshots Data/DataSegment Pagination 1`] = `
   <div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -358,12 +333,7 @@ exports[`Storyshots Data/DataSegment Pagination 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -372,12 +342,7 @@ exports[`Storyshots Data/DataSegment Pagination 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -386,12 +351,7 @@ exports[`Storyshots Data/DataSegment Pagination 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -727,12 +687,7 @@ exports[`Storyshots Data/DataSegment Search Filter 1`] = `
   <div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -741,12 +696,7 @@ exports[`Storyshots Data/DataSegment Search Filter 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -755,12 +705,7 @@ exports[`Storyshots Data/DataSegment Search Filter 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -769,12 +714,7 @@ exports[`Storyshots Data/DataSegment Search Filter 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -857,12 +797,7 @@ exports[`Storyshots Data/DataSegment Simple 1`] = `
   <div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -871,12 +806,7 @@ exports[`Storyshots Data/DataSegment Simple 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -885,12 +815,7 @@ exports[`Storyshots Data/DataSegment Simple 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -899,12 +824,7 @@ exports[`Storyshots Data/DataSegment Simple 1`] = `
     </div>
     <div
       className="ui segment"
-      onClick={[Function]}
-      style={
-        Object {
-          "cursor": "pointer",
-        }
-      }
+      style={Object {}}
     >
       <h2>
         Item 
@@ -992,16 +912,7 @@ exports[`Storyshots Data/DataTable Action Buttons 1`] = `
       >
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1021,16 +932,7 @@ exports[`Storyshots Data/DataTable Action Buttons 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1050,16 +952,7 @@ exports[`Storyshots Data/DataTable Action Buttons 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1079,16 +972,7 @@ exports[`Storyshots Data/DataTable Action Buttons 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1108,16 +992,7 @@ exports[`Storyshots Data/DataTable Action Buttons 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1265,11 +1140,7 @@ exports[`Storyshots Data/DataTable Expandable Row 1`] = `
       >
         <tr
           className=""
-          onBlur={[Function]}
           onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
           style={
             Object {
               "cursor": "pointer",
@@ -1294,11 +1165,7 @@ exports[`Storyshots Data/DataTable Expandable Row 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
           onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
           style={
             Object {
               "cursor": "pointer",
@@ -1323,11 +1190,7 @@ exports[`Storyshots Data/DataTable Expandable Row 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
           onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
           style={
             Object {
               "cursor": "pointer",
@@ -1352,11 +1215,7 @@ exports[`Storyshots Data/DataTable Expandable Row 1`] = `
         </tr>
         <tr
           className=" active"
-          onBlur={[Function]}
           onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
           style={
             Object {
               "cursor": "pointer",
@@ -1472,16 +1331,7 @@ exports[`Storyshots Data/DataTable Filter Inputs 1`] = `
       >
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1501,16 +1351,7 @@ exports[`Storyshots Data/DataTable Filter Inputs 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1530,16 +1371,7 @@ exports[`Storyshots Data/DataTable Filter Inputs 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1559,16 +1391,7 @@ exports[`Storyshots Data/DataTable Filter Inputs 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1588,16 +1411,7 @@ exports[`Storyshots Data/DataTable Filter Inputs 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1663,16 +1477,7 @@ exports[`Storyshots Data/DataTable Pagination 1`] = `
       >
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1692,16 +1497,7 @@ exports[`Storyshots Data/DataTable Pagination 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1721,16 +1517,7 @@ exports[`Storyshots Data/DataTable Pagination 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1750,16 +1537,7 @@ exports[`Storyshots Data/DataTable Pagination 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -1779,16 +1557,7 @@ exports[`Storyshots Data/DataTable Pagination 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2115,16 +1884,7 @@ exports[`Storyshots Data/DataTable Row Span And Style 1`] = `
       >
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2150,16 +1910,7 @@ exports[`Storyshots Data/DataTable Row Span And Style 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2179,16 +1930,7 @@ exports[`Storyshots Data/DataTable Row Span And Style 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2214,16 +1956,7 @@ exports[`Storyshots Data/DataTable Row Span And Style 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2243,16 +1976,7 @@ exports[`Storyshots Data/DataTable Row Span And Style 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2351,16 +2075,7 @@ exports[`Storyshots Data/DataTable Search Filter 1`] = `
       >
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2380,16 +2095,7 @@ exports[`Storyshots Data/DataTable Search Filter 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2409,16 +2115,7 @@ exports[`Storyshots Data/DataTable Search Filter 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2438,16 +2135,7 @@ exports[`Storyshots Data/DataTable Search Filter 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2467,16 +2155,7 @@ exports[`Storyshots Data/DataTable Search Filter 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          style={
-            Object {
-              "cursor": "pointer",
-            }
-          }
+          style={Object {}}
         >
           <td
             className=""
@@ -2803,11 +2482,7 @@ exports[`Storyshots Data/DataTable Selectable 1`] = `
       >
         <tr
           className=" active"
-          onBlur={[Function]}
           onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
           style={
             Object {
               "cursor": "pointer",
@@ -2832,11 +2507,7 @@ exports[`Storyshots Data/DataTable Selectable 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
           onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
           style={
             Object {
               "cursor": "pointer",
@@ -2861,11 +2532,7 @@ exports[`Storyshots Data/DataTable Selectable 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
           onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
           style={
             Object {
               "cursor": "pointer",
@@ -2890,11 +2557,7 @@ exports[`Storyshots Data/DataTable Selectable 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
           onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
           style={
             Object {
               "cursor": "pointer",
@@ -2919,11 +2582,7 @@ exports[`Storyshots Data/DataTable Selectable 1`] = `
         </tr>
         <tr
           className=""
-          onBlur={[Function]}
           onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
           style={
             Object {
               "cursor": "pointer",


### PR DESCRIPTION
This PR fixes a bug with non-selectable rows and data segment items having `cursor: pointer`. `cursor: pointer` now only appears if the `onClick` handler is actually defined

In this PR I also changed the default values for some other callbacks to `undefined` to prevent the overhead of processing functions.


https://user-images.githubusercontent.com/889383/109278391-c5528580-7818-11eb-9a27-94e2cc4eea0d.mp4

