### PR TITLE
RD-1553 Transpile components using @babel/preset-env

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,7 +7,7 @@ const moduleResolverPlugin = [
 
 module.exports = {
     plugins: [moduleResolverPlugin],
-    presets: ['@babel/preset-react', '@babel/preset-typescript'],
+    presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
     env: {
         test: {
             presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],


### PR DESCRIPTION
Syntax such as `a ?? b` needs to be transpiled for dependant packages to handle it without having to transpile `node_modules` :smile: 

I've done `npm pack` and `npm install` (on the packaged tar) to verify that Stage handles it well now

The offending line with `??` was transpiled to:
```ts
            showCols.push((_child$props$show = child.props.show) !== null && _child$props$show !== void 0 ? _child$props$show : true);
```

(in essence, correctly)

## Output size difference

Before:

```
✔ ~/projects/cloudify/cloudify-ui-components [master|⚑ 1]
11:42 $ du es -s
1146    es
```

After:
```
✔ ~/projects/cloudify/cloudify-ui-components [master|✚ 1]
11:43 $ du es -s
1174    es
```

Meaning an increase of 28 kB

We could probably get it lower if we fine-tune the browserslist, but I'm not sure we have time for that now :slightly_smiling_face: 