### PR TITLE
RD-1567 Stop transpiling ESM imports

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,17 +1,17 @@
-const moduleResolverPlugin = [
-    'module-resolver',
-    {
-        root: ['./src']
-    }
-];
+module.exports = api => {
+    const env = api.env();
+    const testEnvironment = env === 'test';
 
-module.exports = {
-    plugins: [moduleResolverPlugin],
-    presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
-    env: {
-        test: {
-            presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
-            plugins: [moduleResolverPlugin, 'require-context-hook']
-        }
-    }
+    return {
+        plugins: [
+            [
+                'module-resolver',
+                {
+                    root: ['./src']
+                }
+            ],
+            testEnvironment && 'require-context-hook'
+        ].filter(Boolean),
+        presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript']
+    };
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,6 +12,17 @@ module.exports = api => {
             ],
             testEnvironment && 'require-context-hook'
         ].filter(Boolean),
-        presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript']
+        presets: [
+            [
+                '@babel/preset-env',
+                {
+                    // Disables transpiling modules to CommonJS outside of tests
+                    // https://babeljs.io/docs/en/babel-preset-env#modules
+                    modules: testEnvironment ? 'auto' : false
+                }
+            ],
+            '@babel/preset-react',
+            '@babel/preset-typescript'
+        ]
     };
 };


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/cloudify-cosmo/cloudify-ui-components/pull/61 that made it so that ESM imports were transpiled to CommonJS. The biggest problem was that all `highlight.js` languages were included as a result, since an import for 

```ts
import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
```

was transpiled to 

```ts
var _reactSyntaxHighlighter = require("react-syntax-highlighter");
```

The functional changes to the config are in https://github.com/cloudify-cosmo/cloudify-ui-components/commit/f6d7b8c52ad7ad99b1325692b4fe2057571adf79. The changes in the first commit are refactor-only without modifying the behavior.

## Bundle size

After:

```
13:25 $ du es -s
1162    es
```

This means that compared to before https://github.com/cloudify-cosmo/cloudify-ui-components/pull/61, there is only 16 kB of increase.

## Bundle size screenshots

From the Stage repo. Before the fix:

![image](https://user-images.githubusercontent.com/889383/109497396-46688180-7a92-11eb-85c0-a58fc5fe95d0.png)

After the fix:

![image](https://user-images.githubusercontent.com/889383/109497418-4ff1e980-7a92-11eb-9ff0-0edeaeff8f27.png)

Meaning that the vendor bundle size is 4.13 MB, only 0.03 MB more than the previous limit.