### PR TITLE
CY-2513 Use Roboto Regular font in Storybook's sidebar

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,13 @@
+import { addons } from '@storybook/addons';
+import { create } from '@storybook/theming';
+
+addons.setConfig({
+    theme: create({
+        base: 'light',
+        /**
+         * NOTE: the font needs to be manually synchronized with the font in cloudify-ui-common
+         * since importing SCSS does not work in manager.js
+         */
+        fontBase: 'Roboto Regular'
+    })
+});

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,6 +1,8 @@
 import { addons } from '@storybook/addons';
 import { create } from '@storybook/theming';
 
+import 'cloudify-ui-common/styles/font-Roboto-Regular.css';
+
 addons.setConfig({
     theme: create({
         base: 'light',


### PR DESCRIPTION
This PR fixes [CY-2513](https://cloudifysource.atlassian.net/browse/CY-2513).

I could not find a way to allow importing the `theme` file and use the font defined there, similarly to how it is done in `theme.js` (https://github.com/cloudify-cosmo/cloudify-ui-components/blob/e654e010d19778c1ab5831c0d29195b6e4ac8703/.storybook/theme.js#L3-L5)

since SCSS does not seem to be handled correctly in `manager.js` (yet it is handled correctly in `preview.js`). I presume the loading of those 2 files (`manager.js` and `preview.js`) happens in separate places. Thus, `preview.js` can use SCSS (registered in https://github.com/cloudify-cosmo/cloudify-ui-components/blob/e654e010d19778c1ab5831c0d29195b6e4ac8703/.storybook/main.js#L8), whereas `manager.js` cannot.

I have tried importing the SCSS file directly, specifying the loaders in the import path (`!style-loader!css-loader!sass-loader!cloudify-ui-common/...`), but none worked. The error:
![image](https://user-images.githubusercontent.com/889383/111154899-04603500-8594-11eb-950d-a19dbd9863a5.png)


## Screenshots

Before:
![image](https://user-images.githubusercontent.com/889383/111156917-8e110200-8596-11eb-8dba-62bbc14acd37.png)

After:
![image](https://user-images.githubusercontent.com/889383/111159714-b2221280-8599-11eb-91cd-efa99c408f65.png)

---

Overall, I'm not certain about using this font here :smile: It looks odd to me. Maybe I have gotten accustomed to the previous one, though.