### PR TITLE
RD-1911 Upgrade y18n package to fix a security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33941,9 +33941,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.2.tgz",
+      "integrity": "sha512-DnBDwcL54b5xWMM/7RfFg4xs5amYxq2ot49aUfLjQSAracXkGvlZq0txzqr3Pa6Q0ayuCxBcwTzrPUScKY0O8w=="
     },
     "yallist": {
       "version": "2.1.2",


### PR DESCRIPTION
This PR fixes a security vulnerability reported in RD-1911. I've only run `npm audit fix` :slightly_smiling_face: 