### PR TITLE
RD-2690 Fix scrolling form to top when there are errors

### DIFF
--- a/src/components/form/Form/Form.jsx
+++ b/src/components/form/Form/Form.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
-import { Form as FormSemanticUiReact, Radio } from 'semantic-ui-react';
+import { Form as FormSemanticUiReact, Radio, Ref } from 'semantic-ui-react';
 
 import ErrorMessage from 'components/elements/ErrorMessage';
 import FormDropdown from 'components/elements/Dropdown';
@@ -87,13 +87,10 @@ export default function Form({
     scrollToError,
     ...formProps
 }) {
+    const formRef = useRef();
     useEffect(() => {
         if (scrollToError && !_.isEmpty(errors)) {
-            // eslint-disable-next-line react/no-find-dom-node
-            const formElement = ReactDOM.findDOMNode(this);
-            if (formElement) {
-                formElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }
+            formRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
         }
     }, [errors]);
 
@@ -105,11 +102,13 @@ export default function Form({
     }
 
     return (
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        <FormSemanticUiReact {...formProps} onSubmit={onSubmit} error={!_.isEmpty(errors)}>
-            <ErrorMessage header={errorMessageHeader} error={formattedErrors} onDismiss={onErrorsDismiss} />
-            {children}
-        </FormSemanticUiReact>
+        <Ref innerRef={formRef}>
+            {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+            <FormSemanticUiReact {...formProps} onSubmit={onSubmit} error={!_.isEmpty(errors)}>
+                <ErrorMessage header={errorMessageHeader} error={formattedErrors} onDismiss={onErrorsDismiss} />
+                {children}
+            </FormSemanticUiReact>
+        </Ref>
     );
 }
 

--- a/test/Form.test.jsx
+++ b/test/Form.test.jsx
@@ -16,6 +16,18 @@ describe('<Form />', () => {
         expect(wrapper.find('ErrorMessage').prop('error')).toEqual(['Invalid a', 'Invalid b']);
     });
 
+    it('scrolls to errors automatically', () => {
+        const wrapper = mount(<Form errors={null} scrollToError />);
+        const formElement = wrapper.getDOMNode();
+
+        expect(formElement).toBeDefined();
+        const scrollSpy = jest.fn();
+        formElement.scrollIntoView = scrollSpy;
+
+        wrapper.setProps({ errors: { a: 'Invalid a', b: 'Invalid b' } });
+        expect(scrollSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('provides Form.fieldNameValue function handling field value', () => {
         let fieldNameValue;
         const wrapper = mount(


### PR DESCRIPTION
When there are new errors in the form, the functionality for scrolling
the form back to the top to see them was broken since at least 2019-11.

The problem was that the DOM node for `this` cound not have been found
in a function component.

The fix is to use a ref to get a handle to the form and then invoke
scrolling on that.

There is also a new test that makes sure the scroll method is invoked.





## Video

I have installed this new version in Stage, here are the results:

https://user-images.githubusercontent.com/889383/124468262-2f67d200-dd99-11eb-99a3-69cd0a168600.mp4

## The plan
1. Merge this PR
2. Release a new **patch** version of `cloudify-ui-components`
3. Install this new version in `cloudify-stage` (I will skip `cloudify-blueprint-composer`)
4. Add a system test to make sure this scrolling works in Stage (tentative)
5. Raise a new PR for Stage based on points 3 and 4.