### PR TITLE
Fix pointing to use boolean instead of empty string on default scenario on FormField

### DIFF
--- a/src/components/form/Form/FormField.tsx
+++ b/src/components/form/Form/FormField.tsx
@@ -21,7 +21,7 @@ const FieldWrapper: FunctionComponent<FormFieldProps> = ({
     required = false,
     ...fieldProps
 }) => {
-    const errorPointing = get(error, 'pointing', '');
+    const errorPointing = get(error, 'pointing', false);
     const errorContent = get(error, 'content', '');
     const errorLabel = (
         <Label


### PR DESCRIPTION
## Description
Fixing error that always was prompting when using a Form.Field component.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [X] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [X] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [ ] I added proper labels to this PR.




