### PR TITLE
Fix to use treeData correctly and avoid warning deprecated message

### DIFF
--- a/src/components/data/NodesTree/NodesTree.tsx
+++ b/src/components/data/NodesTree/NodesTree.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { castArray, compact, isEmpty } from 'lodash';
 import Tree, { TreeNode } from 'rc-tree';
 import type { TreeProps } from 'rc-tree/lib/Tree';
-import type { DataNode } from 'rc-tree/lib/interface';
 import 'rc-tree/assets/index.css';
 import { Loading } from 'components';
 
@@ -43,22 +42,8 @@ export function NodesTree({
             </Tree>
         );
     }
-    const loop = (data: DataNode[]) => {
-        return compact(data).map(item => {
-            if (item.children) {
-                return (
-                    <TreeNode key={item.key} title={item.title}>
-                        {loop(item.children)}
-                    </TreeNode>
-                );
-            }
-            return <TreeNode key={item.key} title={item.title} />;
-        });
-    };
     return treeData.length ? (
-        <Tree showIcon={showIcon} showLine={showLine} selectable={selectable} {...treeProps}>
-            {loop(treeData)}
-        </Tree>
+        <Tree showIcon={showIcon} showLine={showLine} selectable={selectable} {...treeProps} treeData={treeData} />
     ) : (
         <Loading />
     );


### PR DESCRIPTION
## Description
When using treeData on Nodestree component, use correctly the property and not use data as children.


## Checklist
- [ ] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [ ] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [ ] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [ ] I added proper labels to this PR.
